### PR TITLE
feat(python): add support for .python-version file detection

### DIFF
--- a/src/dpv
+++ b/src/dpv
@@ -968,6 +968,13 @@ dpv_internal_scan_python_version() {
 		return
 	fi
 
+	# use version from .python-version, if available
+	if [ -f ".python-version" ]; then
+		INTERNAL_SCAN_PYTHON_VERSION_source=".python-version"
+		INTERNAL_SCAN_PYTHON_VERSION_version="$(cat .python-version)"
+		return
+	fi
+
 	# use version from pyproject.toml, if available
 	if [ -f "pyproject.toml" ]; then
 		while IFS= read -r line; do


### PR DESCRIPTION
## 🐍 Python Version Detection Enhancement

- Added support for detecting Python version from `.python-version` file
- The system now checks for a `.python-version` file before looking at `pyproject.toml`
- When found, the version is read from this file and used as the Python version
- This helps support projects using tools like pyenv that rely on `.python-version` files
- Maintains backward compatibility with existing version detection methods